### PR TITLE
Add basic military flight tracker example

### DIFF
--- a/military_flight_tracker/README.md
+++ b/military_flight_tracker/README.md
@@ -1,0 +1,21 @@
+# Military Flight Tracker
+
+This is a simple Flask-based web application that displays military flights on an interactive map. It queries the [OpenSky Network](https://opensky-network.org/) API and filters aircraft using a list of common military ICAO24 prefixes. The data is refreshed every 30 seconds and visualized using [Leaflet](https://leafletjs.com/).
+
+## Setup
+
+1. Create a Python virtual environment and install dependencies:
+
+```bash
+pip install Flask requests
+```
+
+2. Run the application:
+
+```bash
+python app.py
+```
+
+3. Open your browser at [http://localhost:5000](http://localhost:5000) to see the map.
+
+The application fetches live flight data from OpenSky Network, so network access is required.

--- a/military_flight_tracker/app.py
+++ b/military_flight_tracker/app.py
@@ -1,0 +1,59 @@
+from flask import Flask, jsonify, render_template
+import requests
+
+app = Flask(__name__)
+
+# Some common ICAO24 prefixes used by military aircraft
+MILITARY_PREFIXES = [
+    "ae",  # United States
+    "43c", # United Kingdom
+    "3f",  # Germany
+    "3e",  # Germany
+    "e8",  # Japan
+    "880", # South Korea
+    "894", # India
+]
+
+OPEN_SKY_URL = "https://opensky-network.org/api/states/all"
+
+def is_military(icao24):
+    icao24 = icao24.lower()
+    return any(icao24.startswith(prefix) for prefix in MILITARY_PREFIXES)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/api/military-flights')
+def military_flights():
+    try:
+        resp = requests.get(OPEN_SKY_URL, params={"extended": "1"}, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+    states = data.get('states', [])
+    flights = []
+    for s in states:
+        if not s:
+            continue
+        icao24 = s[0]
+        if is_military(icao24):
+            flight = {
+                "icao24": icao24,
+                "callsign": s[1].strip() if s[1] else "",
+                "origin_country": s[2],
+                "time_position": s[3],
+                "longitude": s[5],
+                "latitude": s[6],
+                "baro_altitude": s[7],
+                "on_ground": s[8],
+                "velocity": s[9],
+            }
+            if flight["latitude"] is not None and flight["longitude"] is not None:
+                flights.append(flight)
+    return jsonify({"flights": flights})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/military_flight_tracker/templates/index.html
+++ b/military_flight_tracker/templates/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Military Flight Tracker</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <style>
+        html, body, #map {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+</head>
+<body>
+<div id="map"></div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+    var map = L.map('map').setView([20,0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    async function fetchFlights() {
+        const resp = await fetch('/api/military-flights');
+        const data = await resp.json();
+        return data.flights || [];
+    }
+
+    var markers = [];
+
+    async function updateFlights() {
+        const flights = await fetchFlights();
+        markers.forEach(m => map.removeLayer(m));
+        markers = flights.map(f => {
+            const marker = L.marker([f.latitude, f.longitude]).addTo(map);
+            marker.bindPopup(`<strong>${f.callsign || f.icao24}</strong><br>Altitude: ${f.baro_altitude}<br>Velocity: ${f.velocity}`);
+            return marker;
+        });
+    }
+
+    updateFlights();
+    setInterval(updateFlights, 30000); // refresh every 30 seconds
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple Flask server that queries OpenSky and filters known military ICAO24 hex prefixes
- show results on a small Leaflet webpage
- document how to set up and run the demo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684f83c4bd0883269b149f70afeccacf